### PR TITLE
Add CODEOWNERS file with SRE squad as primary owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS file for legalzoom/.github
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @legalzoom/squad-sre


### PR DESCRIPTION
This PR adds a CODEOWNERS file to designate the SRE squad as the primary owner of this repository.

The CODEOWNERS file is placed in the .github directory and sets @legalzoom/squad-sre as the default owner for all files in the repository.

This standardizes ownership and streamlines the review process.