### PR TITLE
Update GitHub Actions runners for Enterprise Cloud migration

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   docker:
     name: Docker Image
-    runs-on: devops
+    runs-on: devops-github
     steps:
       - uses: actions/checkout@v4
       - id: meta


### PR DESCRIPTION
This PR updates GitHub Actions workflow files to use GitHub Enterprise Cloud runners.